### PR TITLE
Fix off by one error and test all crouchslide qfs in distance precheck

### DIFF
--- a/Brute.cpp
+++ b/Brute.cpp
@@ -78,7 +78,7 @@ void calc_next_node(bool isLeaf, Slot* saveState, bool recurse, int16_t startInd
 				[](bool isLeaf, Slot* s) { calc_next_node(isLeaf, s); });
 		}
 
-		if (is_freefall_angle == false && (isLeaf == false || distance_precheck(x, y, z, hSpd, marioFloorNormalY, marioFloorType) == true)) {
+		if (is_freefall_angle == false) {
 			set<pair<int16_t, float>> yawmags_tested;
 
 			for (int16_t input_x = -128; input_x < 128; input_x++) {


### PR DESCRIPTION
Before it was only checking 0 qf crouchslide but I meant to check 1qf. I also decided to just check all qf possibilities, including 0 because that represents walking->freefall