### PR TITLE
Check input landing frames (dust frames) for solutions

### DIFF
--- a/Brute.cpp
+++ b/Brute.cpp
@@ -321,9 +321,7 @@ bool check_freefall_outcome(
 
 		/* If Mario lands, this position is a candidate for a next level node, depending on what happens after. */
 		if (*marioAction(game) == 0x04000471) { //freefall land
-			/*  Check to see if landing spot is stable or if Mario continues moving into the air, a slope etc.
-			 *  TO-DO: Try all numbers of dust frames with inputs as these will all yield significantly different speeds.
-			 */
+			/* Check to see if landing spot is stable or if Mario continues moving into the air, a slope etc. */
 			for (int i = 0; i < 6; i++) {
 				if (i < dust_frames) {
 					set_inputs(game, Inputs(0b0000000000010000, 127, 127)); /* R button and joystick input for dust (cuts speed by 2% on flat surfaces) */

--- a/Brute.h
+++ b/Brute.h
@@ -11,8 +11,8 @@ void calc_next_node(bool isLeaf, Slot* saveState, bool recurse = false, int16_t 
 bool distance_precheck(float x, float y, float z, float hSpd, float* marioFloorNormalY, int16_t* marioFloorType);
 bool input_precheck(float floorNormalX, float floorNormalY, float floorNormalZ, int16_t floorType);
 void update_mario_state(float x, float y, float z, float hSpd, int16_t fYaw);
-bool check_if_pos_in_main_universe(float x, float z);
-bool check_freefall_outcome(int16_t input_x, int16_t input_y, int16_t fYaw, bool input_matters, bool isLeaf, bool recurse, Slot* saveStateTemp, Slot* saveStateNext, bool* crouchslide_returned_to_main_uni, std::function<void(bool, Slot*)> execute_recursion);
+bool check_if_pos_in_main_universe(float x, float z, bool input_matters, bool* crouchslide_returned_to_main_uni, int16_t fYaw, int16_t input_x, int16_t input_y);
+bool check_freefall_outcome(int16_t input_x, int16_t input_y, int16_t fYaw, bool input_matters, bool isLeaf, bool recurse, Slot* saveStateTemp, Slot* saveStateNext, bool* crouchslide_returned_to_main_uni, int dust_frames, std::function<void(bool, Slot*)> execute_recursion);
 
 #endif
 


### PR DESCRIPTION
Dust frames cut 2% of Mario's speed which amounts a significantly different distribution of positions he can move to, so these should be checked for the leaf nodes

Sometimes solutions will end up duplicating prints. This should be fixed in the future